### PR TITLE
Update to terminal_size 0.2.1, which has smaller code size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rustix"
-version = "0.35.6"
+version = "0.35.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef258c11e17f5c01979a10543a30a4e12faef6aab217a74266e747eefa3aed88"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
 dependencies = [
  "bitflags",
  "errno",
@@ -154,9 +154,9 @@ checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 
 [[package]]
 name = "terminal_size"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11cc4bc2114fdff27d63eaa12d38a71b590efd8aa8976656096aec8d7758d92"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
  "rustix",
  "windows-sys",


### PR DESCRIPTION
On my x86_64-unknown-linux-gnu system, building `cargo-bloat` with
`cargo release` and measuring with the `size` command:

With term_size (current upstream):
1076874   36617     416 1113907  10ff33 target/release/cargo-bloat

With terminal_size 0.2.0 (current RazrFalcon/cargo-bloat#89)
1076378   36569     416 1113363  10fd13 target/release/cargo-bloat

With terminal_size 0.2.1 (this PR):
1076242   36561     416 1113219  10fc83 target/release/cargo-bloat